### PR TITLE
Get get-key command to 100% test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "oclif-dev manifest && oclif-dev readme",
     "test": "npm run lint; TEST=unit nyc --reporter=text mocha --timeout 25000 test/commands/",
-    "test:utils": "npm run lint; TEST=unit nyc --reporter=text mocha --timeout 25000 test/commands/a06.util.test.js",
     "test:integration": "RESTAPI=fullstack.cash TEST=integration nyc --reporter=text mocha --timeout 25000 test/commands/",
     "test:integration:local": "RESTAPI=local TEST=integration nyc --reporter=text mocha  --timeout 25000",
     "test:integration:decatur": "RESTAPI=decatur TEST=integration nyc --reporter=text mocha  --timeout 25000",

--- a/src/commands/get-key.js
+++ b/src/commands/get-key.js
@@ -68,11 +68,16 @@ class GetKey extends Command {
       this.log(`${newAddress}`)
       // this.log(`legacy address: ${legacy}`)
 
-      const slpAddr = this.bchjs.SLP.Address.toSLPAddress(newAddress)
-      console.log(`${slpAddr}`)
+      const slpAddress = this.bchjs.SLP.Address.toSLPAddress(newAddress)
+      console.log(`${slpAddress}`)
+      return {
+        cashAddress: newAddress,
+        slpAddress: slpAddress
+      }
     } catch (err) {
       if (err.message) console.log(err.message)
       else console.log('Error in GetKey.run: ', err)
+      return null
     }
   }
 


### PR DESCRIPTION
[Issue #10 ](https://github.com/Permissionless-Software-Foundation/slp-cli-wallet/issues/10)

The scope of this Issue is to add tests to the get-key command test library in order to achieve 100% test coverage.