### PR TITLE
Get remove-wallet to 100% unit test coverage

### DIFF
--- a/src/commands/remove-wallet.js
+++ b/src/commands/remove-wallet.js
@@ -14,19 +14,16 @@ class RemoveWallet extends Command {
 
       const filename = `${__dirname}/../../wallets/${flags.name}.json`
 
-      this.removeWallet(filename)
+      return this.removeWallet(filename)
     } catch (err) {
       console.log('Error: ', err)
     }
   }
 
   async removeWallet (filename) {
-    try {
-      shelljs.rm(filename)
-    } catch (err) {
-      if (err.code !== 'EEXIT') console.log('Error in removeWallet().')
-      throw err
-    }
+    const result = shelljs.rm(filename)
+    if (!shelljs.error()) return result
+    throw new Error(result.stderr || 'Error in removeWallet().')
   }
 
   // Validate the proper flags are passed in.

--- a/src/commands/remove-wallet.js
+++ b/src/commands/remove-wallet.js
@@ -22,7 +22,9 @@ class RemoveWallet extends Command {
 
   async removeWallet (filename) {
     const result = shelljs.rm(filename)
+
     if (!shelljs.error()) return result
+
     throw new Error(result.stderr || 'Error in removeWallet().')
   }
 
@@ -30,7 +32,9 @@ class RemoveWallet extends Command {
   validateFlags (flags) {
     // Exit if wallet not specified.
     const name = flags.name
-    if (!name || name === '') { throw new Error('You must specify a wallet with the -n flag.') }
+    if (!name || name === '') {
+      throw new Error('You must specify a wallet with the -n flag.')
+    }
 
     return true
   }

--- a/test/commands/a16.remove-wallet.js
+++ b/test/commands/a16.remove-wallet.js
@@ -9,11 +9,11 @@ const sinon = require('sinon')
 
 const CreateWallet = require('../../src/commands/create-wallet')
 const RemoveWallet = require('../../src/commands/remove-wallet')
-const config = require('../../config')
+// const config = require('../../config')
 
 const { bitboxMock } = require('../mocks/bitbox')
 const fs = require('fs')
-const mock = require('mock-fs')
+// const mock = require('mock-fs')
 
 const filename = `${__dirname}/../../wallets/test123.json`
 
@@ -98,7 +98,11 @@ describe('remove-wallet', () => {
     try {
       await removeWallet.run()
     } catch (err) {
-      assert.include(err.message, 'rm: no such file or directory', 'Expected error message.')
+      assert.include(
+        err.message,
+        'rm: no such file or directory',
+        'Expected error message.'
+      )
     }
   })
 
@@ -123,7 +127,11 @@ describe('remove-wallet', () => {
     try {
       await removeWallet.run()
     } catch (err) {
-      assert.include(err.message, "Cannot read property 'name' of undefined", 'Expected error message.')
+      assert.include(
+        err.message,
+        "Cannot read property 'name' of undefined",
+        'Expected error message.'
+      )
     }
   })
 
@@ -138,7 +146,11 @@ describe('remove-wallet', () => {
     try {
       await removeWallet.removeWallet(undefined)
     } catch (err) {
-      assert.include(err.message, 'rm: no paths given', 'Expected error message.')
+      assert.include(
+        err.message,
+        'rm: no paths given',
+        'Expected error message.'
+      )
     }
   })
 
@@ -146,7 +158,11 @@ describe('remove-wallet', () => {
     try {
       await removeWallet.removeWallet('non-existing')
     } catch (err) {
-      assert.include(err.message, 'rm: no such file or directory: non-existing', 'Expected error message.')
+      assert.include(
+        err.message,
+        'rm: no such file or directory: non-existing',
+        'Expected error message.'
+      )
     }
   })
 })

--- a/test/commands/a16.remove-wallet.js
+++ b/test/commands/a16.remove-wallet.js
@@ -1,3 +1,152 @@
 /*
-  This file will hold test for the remove-wallet command.
+  Tests for the remove-wallet command.
 */
+
+'use strict'
+
+const assert = require('chai').assert
+const sinon = require('sinon')
+
+const CreateWallet = require('../../src/commands/create-wallet')
+const RemoveWallet = require('../../src/commands/remove-wallet')
+const config = require('../../config')
+
+const { bitboxMock } = require('../mocks/bitbox')
+const fs = require('fs')
+const mock = require('mock-fs')
+
+const filename = `${__dirname}/../../wallets/test123.json`
+
+// Inspect utility used for debugging.
+const util = require('util')
+util.inspect.defaultOptions = {
+  showHidden: true,
+  colors: true,
+  depth: 1
+}
+
+// Set default environment variables for unit tests.
+if (!process.env.TEST) process.env.TEST = 'unit'
+const deleteFile = () => {
+  const prom = new Promise((resolve, reject) => {
+    fs.unlink(filename, () => {
+      resolve(true)
+    }) // Delete wallets file
+  })
+  return prom
+}
+describe('remove-wallet', () => {
+  let BITBOX
+  let removeWallet
+  let sandbox
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox()
+
+    removeWallet = new RemoveWallet()
+
+    // By default, use the mocking library instead of live calls.
+    BITBOX = bitboxMock
+    removeWallet.BITBOX = BITBOX
+    await deleteFile()
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it('run(): should run the function', async () => {
+    const flags = {
+      name: 'test123',
+      testnet: true
+    }
+    // Mock methods that will be tested elsewhere.
+    sandbox.stub(removeWallet, 'parse').returns({ flags: flags })
+
+    const newWallet = new CreateWallet()
+    await newWallet.createWallet(filename, 'testnet')
+    const result = await removeWallet.run()
+    assert.equal(result.code, 0)
+    assert.equal(result.stdout, '')
+    assert.equal(result.stderr, null)
+  })
+  it('run(): should run the function in mainnet', async () => {
+    const flags = {
+      name: 'test123'
+    }
+    // Mock methods that will be tested elsewhere.
+    sandbox.stub(removeWallet, 'parse').returns({ flags: flags })
+
+    const newWallet = new CreateWallet()
+    await newWallet.createWallet(filename, false)
+    const result = await removeWallet.run()
+    assert.equal(result.code, 0)
+    assert.equal(result.stdout, '')
+    assert.equal(result.stderr, null)
+  })
+
+  it('should display error on non-existing wallet', async () => {
+    const flags = {
+      name: 'test121',
+      testnet: true
+    }
+    // Mock methods that will be tested elsewhere.
+    sandbox.stub(removeWallet, 'parse').returns({ flags: flags })
+
+    const newWallet = new CreateWallet()
+    await newWallet.createWallet(filename, 'testnet')
+    try {
+      await removeWallet.run()
+    } catch (err) {
+      assert.include(err.message, 'rm: no such file or directory', 'Expected error message.')
+    }
+  })
+
+  it('validateFlags() should throw error if name is not supplied.', () => {
+    try {
+      removeWallet.validateFlags({})
+    } catch (err) {
+      assert.include(
+        err.message,
+        'You must specify a wallet with the -n flag',
+        'Expected error message.'
+      )
+    }
+  })
+
+  it('should throw error on invalid flags (missing name)', async () => {
+    // Mock methods that will be tested elsewhere.
+    sandbox.stub(removeWallet, 'parse').returns({})
+
+    const newWallet = new CreateWallet()
+    await newWallet.createWallet(filename, 'testnet')
+    try {
+      await removeWallet.run()
+    } catch (err) {
+      assert.include(err.message, "Cannot read property 'name' of undefined", 'Expected error message.')
+    }
+  })
+
+  it('should remove wallet file', async () => {
+    const newWallet = new CreateWallet()
+    await newWallet.createWallet(filename, 'testnet')
+    await removeWallet.removeWallet(filename)
+    assert.equal(fs.existsSync(filename), false)
+  })
+
+  it('should throw error on shell command execution error', async () => {
+    try {
+      await removeWallet.removeWallet(undefined)
+    } catch (err) {
+      assert.include(err.message, 'rm: no paths given', 'Expected error message.')
+    }
+  })
+
+  it('should throw error on non-existing file', async () => {
+    try {
+      await removeWallet.removeWallet('non-existing')
+    } catch (err) {
+      assert.include(err.message, 'rm: no such file or directory: non-existing', 'Expected error message.')
+    }
+  })
+})


### PR DESCRIPTION
Issue #17  (Bounty N%15) - Get remove-wallet to 100% unit test coverage

Seems there are some changes in `shelljs.rm()` command - it does not throw exceptions any more. Changed the code a little to reflect this.

